### PR TITLE
Remove unused variables, tweak test imports

### DIFF
--- a/tests/test_track_objects_block.py
+++ b/tests/test_track_objects_block.py
@@ -1,7 +1,5 @@
-from nio.block.terminals import DEFAULT_TERMINAL
 from nio.signal.base import Signal
 from nio.testing.block_test_case import NIOBlockTestCase
-from ..track_objects_block import TrackObjects
 
 from unittest.mock import patch, MagicMock
 import sys
@@ -12,7 +10,7 @@ class TestTrackObjects(NIOBlockTestCase):
     def setUp(self):
         super().setUp()
         sys.modules['cv2'] = MagicMock()
-        sys.modules['object_tracker'] = MagicMock()
+        sys.modules['imutils'] = MagicMock()
         from ..track_objects_block import TrackObjects
         global TrackObjects
 

--- a/track_objects_block.py
+++ b/track_objects_block.py
@@ -1,6 +1,4 @@
-from collections import deque
 from enum import Enum
-import numpy as np
 import imutils
 import cv2
 
@@ -53,9 +51,6 @@ class TrackObjects(Block):
             self.video_capture = cv2.VideoCapture(self.video_ref())
 
     def process_signals(self, signals):
-        counter = 0
-        (dX, dY) = (0, 0)
-        direction = ""
 
         for signal in signals:
             try:
@@ -66,7 +61,6 @@ class TrackObjects(Block):
                 break
 
             frame = imutils.resize(frame, width=600)
-            blurred = cv2.GaussianBlur(frame, (11, 11), 0)
             hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
 
             # construct a mask and perform dialations and erosions to remove


### PR DESCRIPTION
I'm guessing the `range-detector.py` file is there for a reason, but want to note that it isn't actually used in the block code